### PR TITLE
Add exportc pragma to fsym to prevent dead code elimination #0.18.1

### DIFF
--- a/emextra.nim
+++ b/emextra.nim
@@ -33,7 +33,7 @@ template defun*(self, fsym, max_args, body: untyped) {.dirty.} = ## \
 
   proc `fsym`*(env: ptr emacs_env, nargs: ptrdiff_t,
                args: ptr array[0..max_args, emacs_value],
-               data: pointer): emacs_value {.extern: "nimEmacs_" & self.libName & "_$1".} =
+               data: pointer): emacs_value {.exportc,extern: "nimEmacs_" & self.libName & "_$1".} =
     body
 
 


### PR DESCRIPTION
Fixes https://github.com/yuutayamada/nim-emacs-module/issues/2.

The exportc pragma is position dependent! It needed to be
added **before** extern.

Thanks to @Yardanico!

---

This PR is based off @Lompik's PR https://github.com/yuutayamada/nim-emacs-module/pull/3. Please merge this after merging that one.